### PR TITLE
fix(e2e): allow root remote access for mysql/percona provisioning

### DIFF
--- a/tests/e2e_guardian/scripts/provision_db.sh
+++ b/tests/e2e_guardian/scripts/provision_db.sh
@@ -303,6 +303,7 @@ else
   set +e
   docker run -d --name "$NAME" -p "$PORT:3306" \
     -e MYSQL_ROOT_PASSWORD="$ROOT_PASS" \
+    -e MYSQL_ROOT_HOST="%" \
     -e MYSQL_DATABASE="$DB_NAME" \
     "$IMAGE" >/dev/null
   rc=$?
@@ -318,6 +319,7 @@ else
     docker rm -f "$NAME" >/dev/null 2>&1 || true
     docker run -d --name "$NAME" -p "$PORT:3306" \
       -e MYSQL_ROOT_PASSWORD="$ROOT_PASS" \
+      -e MYSQL_ROOT_HOST="%" \
       -e MYSQL_DATABASE="$DB_NAME" \
       "$fallback_image" >/dev/null
     IMAGE="$fallback_image"


### PR DESCRIPTION
• Titre PR
  fix(e2e): stabilize MySQL/Percona readiness in matrix (GUARD-100 on mysql 8.4)

  Contexte
  Le job CI e2e-bash (mysql-8-4, mysql:8.4, mysql) échouait sur GUARD-100 avec:

  - DB did not become ready
  - puis échec générique côté runner.

  Cause racine
  Pour les conteneurs MySQL/Percona, le test utilise:

  - mysqladmin ping -h127.0.0.1 -P<port> -uroot -p<pass>
    Depuis l’hôte (runner), donc connexion TCP distante.
    Sans MYSQL_ROOT_HOST=%, root peut ne pas être autorisé en remote selon image/version, et la readiness échoue même si le conteneur tourne.

  Changement de code
  Fichier modifié:

  - tests/e2e_guardian/scripts/provision_db.sh

  Diff fonctionnel:

  - ajout de -e MYSQL_ROOT_HOST="%" dans les docker run pour:

  1. flux MySQL/Percona normal
  2. flux fallback Percona 8.0
