### PR TITLE
fix(timeout): reject late successful select queries over max time

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -391,6 +391,23 @@ final class Tools
             }
 
             $durationMs = (int) round((microtime(true) - $startedAt) * 1000);
+            if (self::didSuccessfulQueryExceedTimeout($originalSql, $durationMs)) {
+                QueryLogger::log([
+                    'event' => 'mcp_sql_query',
+                    'tool' => $toolName,
+                    'sql' => QueryLogger::formatSql($executedSql),
+                    'sqlOriginal' => QueryLogger::formatSql($originalSql),
+                    'params' => $params,
+                    'rowCount' => count($rows),
+                    'durationMs' => $durationMs,
+                    'plan' => self::buildExecutionPlan($originalSql, $params),
+                    'status' => 'error',
+                    'error' => 'guard [execution time reached]',
+                    'errorRaw' => 'query completed after configured MAX_SELECT_TIME_S threshold',
+                ]);
+                throw new InvalidArgumentException('guard [execution time reached]');
+            }
+
             QueryLogger::log([
                 'event' => 'mcp_sql_query',
                 'tool' => $toolName,
@@ -509,6 +526,21 @@ final class Tools
             $sql,
             1
         ) ?? $sql;
+    }
+
+    private static function didSuccessfulQueryExceedTimeout(string $sql, int $durationMs): bool
+    {
+        $normalized = SqlGuard::stripComments($sql);
+        if (!preg_match('/^(select|with)\b/i', $normalized)) {
+            return false;
+        }
+
+        $timeoutSeconds = Env::getInt('MAX_SELECT_TIME_S', 5);
+        if ($timeoutSeconds <= 0) {
+            return false;
+        }
+
+        return $durationMs > ($timeoutSeconds * 1000);
     }
 
     private static function enforceDbSelectPolicies(string $sql, array $params): void

--- a/tests/ToolsSelectTimeoutVersionTest.php
+++ b/tests/ToolsSelectTimeoutVersionTest.php
@@ -156,10 +156,39 @@ final class ToolsSelectTimeoutVersionTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider successfulDurationTimeoutProvider
+     */
+    public function testSuccessfulQueryDurationPastThresholdIsDetected(
+        string $sql,
+        int $durationMs,
+        bool $expected
+    ): void {
+        $actual = $this->invokeDidSuccessfulQueryExceedTimeout($sql, $durationMs);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function successfulDurationTimeoutProvider(): array
+    {
+        return [
+            'select_below_threshold' => ['SELECT 1', 4999, false],
+            'select_above_threshold' => ['SELECT SLEEP(7)', 5001, true],
+            'cte_above_threshold' => ['WITH x AS (SELECT 1) SELECT * FROM x', 5001, true],
+            'show_never_flagged' => ['SHOW TABLES', 12000, false],
+            'disabled_threshold' => ['SELECT 1', 0, false],
+        ];
+    }
+
     private function invokeApplySelectTimeout(string $sql): string
     {
         $method = new ReflectionMethod(Tools::class, 'applySelectTimeout');
         return (string) $method->invoke(null, $sql);
+    }
+
+    private function invokeDidSuccessfulQueryExceedTimeout(string $sql, int $durationMs): bool
+    {
+        $method = new ReflectionMethod(Tools::class, 'didSuccessfulQueryExceedTimeout');
+        return (bool) $method->invoke(null, $sql, $durationMs);
     }
 
     private function setDbStatic(string $property, mixed $value): void


### PR DESCRIPTION
## Validation

  ### PHPUnit
  ```bash
  cd /var/www/mcp-mysql
  php vendor/bin/phpunit --configuration phpunit.xml

  Expected:

  - OK
  - 53 tests, 88 assertions

  ### Targeted unit test

  cd /var/www/mcp-mysql
  php vendor/bin/phpunit --configuration phpunit.xml --filter ToolsSelectTimeoutVersionTest

  Expected:

  - timeout helper tests pass
  - late-success timeout detection is covered

  ### E2E repro on MySQL 8.4

  cd /var/www/mcp-mysql

  docker rm -f ci-mysql84-test >/dev/null 2>&1 || true

  docker run -d --name ci-mysql84-test \
    -p 3308:3306 \
    -e MYSQL_ROOT_PASSWORD=root_change_me \
    -e MYSQL_DATABASE=sakila \
    mysql:8.4

  for i in $(seq 1 90); do
    if mysql -h127.0.0.1 -P3308 -uroot -proot_change_me -e 'SELECT 1' >/dev/null 2>&1; then
      break
    fi
    sleep 1
  done

  mysql -h127.0.0.1 -P3308 -uroot -proot_change_me <<'SQL'
  CREATE DATABASE IF NOT EXISTS sakila;
  USE sakila;
  CREATE TABLE IF NOT EXISTS film (film_id INT PRIMARY KEY) ENGINE=InnoDB;
  INSERT IGNORE INTO film (film_id) VALUES (1),(2),(3);
  CREATE USER IF NOT EXISTS 'my_user_mcp_ro'@'%' IDENTIFIED BY 'my_password';
  REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'my_user_mcp_ro'@'%';
  GRANT SELECT ON sakila.* TO 'my_user_mcp_ro'@'%';
  FLUSH PRIVILEGES;
  SQL

  cat > .env <<'ENV'
  DB_HOST=127.0.0.1
  DB_PORT=3308
  DB_NAME=sakila
  DB_USER=my_user_mcp_ro
  DB_PASS=my_password
  MCP_TOKEN=my_token
  MAX_ROWS_DEFAULT=1000
  MAX_ROWS_HARD=5000
  MAX_SELECT_TIME_S=5
  WHERE_FULLSCAN_MAX_ROWS=30000
  MAX_CONCURRENT_DB_SELECT=3
  MCP_QUERY_LOG=/tmp/mcp_mariadb_ci_query.log
  ENV

  php -S 127.0.0.1:50002 -t public public/index.php >/tmp/mcp50002.log 2>&1 &
  echo $! >/tmp/mcp50002.pid
  sleep 2

  MCP_ENDPOINT=http://127.0.0.1:50002/mcp \
  DB_ENGINE=mysql \
  ./tests/e2e_guardian/bin/run.sh --unit --id GUARD-100 --log-level TRACE --explain

  kill "$(cat /tmp/mcp50002.pid)" || true
  docker rm -f ci-mysql84-test || true

  Expected:

  - GUARD-100 returns PASS
  - resolved.config shows DB_ENGINE=mysql
  - the query is rejected as guard [execution time reached]

  ### Push-sequence repro matching CI

  cd /var/www/mcp-mysql

  MCP_ENDPOINT=http://127.0.0.1:50002/mcp DB_ENGINE=mysql ./tests/e2e_guardian/bin/run.sh --unit --id GUARD-001
  MCP_ENDPOINT=http://127.0.0.1:50002/mcp DB_ENGINE=mysql ./tests/e2e_guardian/bin/run.sh --block --block auth
  MCP_ENDPOINT=http://127.0.0.1:50002/mcp DB_ENGINE=mysql ./tests/e2e_guardian/bin/run.sh --block --block sql-guards
  MCP_ENDPOINT=http://127.0.0.1:50002/mcp DB_ENGINE=mysql ./tests/e2e_guardian/bin/run.sh --unit --id GUARD-100 --log-level TRACE --explain

  Expected:

  - GUARD-001 pass
  - GUARD-010 pass
  - GUARD-020 pass
  - GUARD-100 pass

  ### What this specifically proves

  - MySQL 8.4 no longer escapes the timeout guard when MAX_EXECUTION_TIME(...) returns a late success instead of an SQL exception.
  - Successful-but-too-late SELECT / WITH queries are now treated as guard [execution time reached].
