### PR TITLE
feat(auto-kill): add safe db query ownership kill guard

### DIFF
--- a/bin/mcp-auto-kill-monitor.php
+++ b/bin/mcp-auto-kill-monitor.php
@@ -1,0 +1,120 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$composerAutoload = $root . '/vendor/autoload.php';
+if (is_file($composerAutoload)) {
+    require_once $composerAutoload;
+} else {
+    require_once $root . '/src/Env.php';
+    require_once $root . '/src/Http.php';
+    require_once $root . '/src/Db.php';
+    require_once $root . '/src/AccountSecurity.php';
+    require_once $root . '/src/SqlGuard.php';
+    require_once $root . '/src/JsonRpc.php';
+    require_once $root . '/src/QueryLogger.php';
+    require_once $root . '/src/AutoKill.php';
+    require_once $root . '/src/Tools.php';
+    require_once $root . '/src/App.php';
+}
+
+$encoded = $argv[1] ?? '';
+if ($encoded === '') {
+    exit(1);
+}
+
+$json = base64_decode($encoded, true);
+if (!is_string($json) || $json === '') {
+    exit(1);
+}
+
+$payload = json_decode($json, true);
+if (!is_array($payload)) {
+    exit(1);
+}
+
+$envFile = (string) ($payload['envFile'] ?? ($root . '/.env'));
+if (is_file($envFile)) {
+    Env::load($envFile);
+}
+
+$timeoutMs = max(0, (int) ($payload['timeoutMs'] ?? 0));
+$pollMs = max(50, (int) ($payload['pollMs'] ?? 200));
+$stopFile = (string) ($payload['stopFile'] ?? '');
+$connectionId = (int) ($payload['connectionId'] ?? 0);
+$tool = (string) ($payload['tool'] ?? 'db_select');
+$token = (string) ($payload['token'] ?? '');
+$dbUser = (string) ($payload['dbUser'] ?? '');
+$dbName = (string) ($payload['dbName'] ?? '');
+$sqlOriginal = (string) ($payload['sqlOriginal'] ?? '');
+
+if ($connectionId <= 0 || $timeoutMs <= 0) {
+    exit(0);
+}
+
+$deadline = microtime(true) + ($timeoutMs / 1000);
+while (microtime(true) < $deadline) {
+    if ($stopFile !== '' && is_file($stopFile)) {
+        exit(0);
+    }
+    usleep($pollMs * 1000);
+}
+
+if ($stopFile !== '' && is_file($stopFile)) {
+    exit(0);
+}
+
+try {
+    $monitorPdo = Db::freshPdo();
+    $row = Db::processlistRowById($monitorPdo, $connectionId);
+    if ($row === null) {
+        QueryLogger::log([
+            'event' => 'mcp_auto_kill',
+            'status' => 'skipped',
+            'reason' => 'process_not_found',
+            'tool' => $tool,
+            'token' => $token,
+            'connectionId' => $connectionId,
+        ]);
+        exit(0);
+    }
+
+    if (!AutoKill::isKillableProcesslistRow($row, $connectionId, $dbUser, $dbName)) {
+        QueryLogger::log([
+            'event' => 'mcp_auto_kill',
+            'status' => 'skipped',
+            'reason' => 'ownership_not_proven',
+            'tool' => $tool,
+            'token' => $token,
+            'connectionId' => $connectionId,
+            'processlist' => $row,
+        ]);
+        exit(0);
+    }
+
+    Db::killQuery($monitorPdo, $connectionId);
+    QueryLogger::log([
+        'event' => 'mcp_auto_kill',
+        'status' => 'killed',
+        'tool' => $tool,
+        'token' => $token,
+        'connectionId' => $connectionId,
+        'dbUser' => $dbUser,
+        'dbName' => $dbName,
+        'sqlOriginal' => QueryLogger::formatSql($sqlOriginal),
+    ]);
+} catch (Throwable $e) {
+    QueryLogger::log([
+        'event' => 'mcp_auto_kill',
+        'status' => 'error',
+        'tool' => $tool,
+        'token' => $token,
+        'connectionId' => $connectionId,
+        'error' => $e->getMessage(),
+    ]);
+    exit(1);
+}
+
+exit(0);

--- a/docs/new-features/11-7010-auto-kill-fixed.md
+++ b/docs/new-features/11-7010-auto-kill-fixed.md
@@ -1,0 +1,321 @@
+# Branch
+- Name: `feature/7010-auto-kill-fixed`
+
+## Scope
+- Short description of the feature: automatically kill MCP-owned queries that exceed allowed execution time.
+- Main goal: enforce hard runtime cutoffs even if the database keeps executing.
+- Why it matters for this MCP server: time guards are weak if runaway queries continue server-side after client timeout.
+
+## Current State
+- Historical progress marked the original feature as `partial`.
+- The fixed implementation now uses one dedicated DB connection per guarded `db_select` request when `AUTO_KILL_DB_SELECT=1`.
+- Ownership is proven by the exact `CONNECTION_ID()` of that dedicated connection while it is still executing a live `Query/Execute`.
+- Current test status: dedicated PHPUnit coverage added, plus two new E2E guards (`GUARD-140`, `GUARD-141`) for positive and negative paths.
+
+## Expected Result
+- Functional outcome expected: long MCP query is terminated at the DB level near the configured threshold.
+- Security outcome expected: service cannot be abused to leave expensive orphaned queries behind.
+- Operational outcome expected: kill action is auditable and targets only MCP-owned sessions.
+
+## Remaining Work
+- [x] Implement reliable mapping between MCP request and DB processlist entry.
+- [x] Add tests proving non-MCP queries are never killed.
+- [ ] Validate engine/version differences for `SHOW PROCESSLIST` and `KILL QUERY` on every supported matrix target.
+
+## Tests To Provide
+- [x] Normal path: MCP query over threshold is killed (`GUARD-140`).
+- [x] Failure path: external user query over threshold is not killed (`GUARD-141`).
+- [x] Regression path: short MCP query is never killed (existing timeout regression path stays unchanged because auto-kill is opt-in).
+- [ ] Edge cases: concurrent long queries, connection reuse, race between timeout and completion.
+- [ ] Performance / load behavior if relevant: processlist polling does not overload DB.
+- [ ] Security abuse cases if relevant: attacker tries to get the system to kill unrelated sessions.
+- [x] launch long `SLEEP` via direct mysql (sans MCP) and prove MCP does not kill this external session.
+
+## Extreme Cases To Cover
+- Session ID reused after disconnect.
+- Multiple MCP queries from one connection or pooled connections.
+- Query already finished when kill fires.
+- Replica with delayed processlist visibility.
+
+## Risks
+- Security risks: wrong-session kill is operationally dangerous.
+- Production risks: excessive polling or kill storms can destabilize a replica.
+- Compatibility risks: processlist columns and privileges differ across engines.
+- Observability / supportability risks: operators need proof of why a query was killed.
+
+## Validation Status
+- Status: `ready for validation`
+- Confidence level: `medium`
+- Reason: ownership model is now strict and testable, but full DB matrix validation is still pending before claiming production validation.
+
+## References
+- Related files or classes: `src/AutoKill.php`, `src/Tools.php`, `src/Db.php`, `bin/mcp-auto-kill-monitor.php`
+- Related PRs / commits if identifiable: security hardening track `7010`
+
+## Implementation Notes
+- Auto-kill is opt-in through `AUTO_KILL_DB_SELECT=1`.
+- When enabled, `db_select` runs on a fresh dedicated PDO connection instead of the shared cached handle.
+- The monitor process gets the exact `CONNECTION_ID()` from that dedicated connection.
+- The monitor waits until the configured timeout, then re-checks `information_schema.PROCESSLIST`.
+- It will only run `KILL QUERY <id>` if:
+  - the processlist row still exists,
+  - the row id is the exact tracked connection id,
+  - the row is still in `Query` or `Execute`,
+  - the DB user and schema still match the tracked MCP session.
+- If the query already finished, became `Sleep`, disappeared from processlist, or ownership is not proven, no kill happens.
+- This design avoids broad heuristics on SQL text, user only, host only, or duration only.
+
+Prompte detaillé :
+
+
+Projet: MariaDB-Guard-RO-MCP
+
+Tu travailles sur le dépôt du projet `MariaDB-Guard-RO-MCP`.
+
+Ta mission est d’implémenter, fiabiliser, tester et documenter la feature suivante dans une nouvelle branche Git :
+
+# Branch
+feature/7010-auto-kill-fixed
+
+# Contexte
+Cette feature doit permettre de tuer automatiquement les requêtes SQL lancées par le serveur MCP quand elles dépassent le temps d’exécution autorisé.
+
+Le but n’est pas seulement de couper côté client ou applicatif, mais bien d’imposer une coupure réelle côté base de données, même si la requête continue à tourner côté serveur SQL après timeout applicatif.
+
+Aujourd’hui, l’état de cette feature est `partial` :
+- des changements existent côté app / tool handling ;
+- mais il n’existe pas encore de preuve robuste que le mapping entre requête MCP et entrée `SHOW PROCESSLIST` est fiable ;
+- il n’existe pas encore de validation bout en bout prouvant que seules les requêtes appartenant au MCP sont tuées ;
+- il n’existe pas encore de preuve que les sessions externes (hors MCP) sont préservées.
+
+Les logs de rebuild génériques ne suffisent pas à valider cette feature en sécurité.
+
+# Objectif principal
+Implémenter une version robuste, sûre et observable de l’auto-kill des requêtes MCP trop longues.
+
+# Résultat attendu
+## Fonctionnel
+- Une requête MCP qui dépasse le seuil configuré est tuée réellement au niveau SGBD, dans une fenêtre proche du seuil prévu.
+
+## Sécurité
+- Le service ne doit pas pouvoir laisser derrière lui des requêtes orphelines coûteuses.
+- Le mécanisme d’auto-kill ne doit jamais tuer une requête non-MCP.
+
+## Opérationnel
+- Chaque kill doit être traçable / auditable.
+- Le ciblage doit être strictement limité aux sessions appartenant au MCP.
+- Le comportement doit être compréhensible en production.
+
+# Périmètre technique
+Travaille en priorité sur ces fichiers, si pertinent :
+- `src/App.php`
+- `src/Tools.php`
+- `src/Db.php`
+
+Tu peux créer de nouveaux fichiers / classes / helpers / tests / docs si nécessaire.
+
+# Contraintes fortes
+1. Ne casse pas le comportement read-only du serveur MCP.
+2. Ne fais aucun kill “large” ou heuristique dangereuse basée uniquement sur :
+   - le texte SQL,
+   - l’utilisateur SQL,
+   - l’host,
+   - la durée seule,
+   - ou une simple recherche approximative dans `SHOW PROCESSLIST`.
+3. Le kill ne doit viser qu’une requête dont la propriété “MCP-owned” est démontrable.
+4. En cas de doute sur l’identité de la session SQL, il faut préférer :
+   - ne pas tuer,
+   - logguer clairement l’échec de corrélation,
+   - retourner un état explicite.
+5. Préserve la compatibilité autant que possible avec MariaDB / MySQL, et documente précisément les écarts de comportement.
+6. Toute logique de polling processlist doit être bornée, mesurée et justifiée pour éviter la surcharge.
+7. Ne fais pas d’implémentation “magique” non testable. Toute hypothèse doit être vérifiable par tests.
+
+# Travail demandé
+
+## 1. Analyse de l’existant
+Avant de coder, lis l’implémentation actuelle et identifie :
+- comment une requête MCP est envoyée à la base ;
+- où le timeout applicatif est géré ;
+- comment l’identifiant de session SQL pourrait être récupéré de manière fiable ;
+- si la connexion DB est unique, réutilisée, poolée ou recréée ;
+- quels sont les risques actuels de mauvais kill.
+
+Dans ton rendu, explique brièvement :
+- l’architecture actuelle du flow SQL ;
+- ce qui rend la version actuelle `partial` ;
+- le point exact où il faut attacher la logique de tracking d’ownership.
+
+## 2. Concevoir un mécanisme fiable de corrélation MCP -> session SQL
+Implémente ou valide une méthode robuste pour associer une requête MCP à l’entrée processlist correcte.
+
+Tu dois privilégier une stratégie fiable et explicable, par exemple :
+- récupération stricte du `CONNECTION_ID()` / thread id SQL de la connexion réellement utilisée pour exécuter la requête ;
+- stockage local de métadonnées de requête côté app ;
+- journalisation d’un identifiant interne de requête MCP ;
+- éventuel marquage contextuel si disponible et sûr ;
+- tout mécanisme additionnel de corrélation si nécessaire.
+
+Mais attention :
+- si la connexion est réutilisée pour plusieurs requêtes, traite correctement les collisions et courses ;
+- si plusieurs requêtes MCP concurrentes existent, le système doit rester correct ;
+- si l’ID de session est réutilisé après déconnexion, évite les faux positifs ;
+- si la requête a déjà fini quand le kill part, le système doit le gérer proprement.
+
+Tu dois documenter clairement le modèle de propriété retenu :
+- qu’est-ce qui prouve qu’une requête appartient au MCP ;
+- quelles preuves minimales sont exigées avant un kill ;
+- dans quels cas on refuse volontairement de tuer.
+
+## 3. Implémenter l’auto-kill sûr
+Ajoute le mécanisme qui :
+- détecte qu’une requête MCP a dépassé le seuil autorisé ;
+- tente le kill côté DB ;
+- vérifie / gère le résultat ;
+- loggue l’événement proprement.
+
+Attendus :
+- kill borné dans le temps ;
+- pas de boucle infinie ;
+- pas de polling agressif ;
+- logs explicites ;
+- comportement propre si la requête a déjà fini ;
+- comportement propre si le kill échoue faute de privilèges ou de visibilité processlist.
+
+Documente aussi :
+- privilèges requis pour observer et tuer ;
+- différences possibles entre MariaDB et MySQL ;
+- impacts éventuels sur réplica / primaire.
+
+## 4. Tests obligatoires
+Ajoute des tests automatisés et/ou scripts de validation reproductibles couvrant au minimum :
+
+### Normal path
+- une requête MCP longue dépasse le seuil ;
+- elle est tuée au niveau DB ;
+- le résultat côté MCP reflète bien un timeout / kill réel.
+
+### Failure path
+- une requête lancée hors MCP (par exemple via client mysql direct) dépasse le seuil ;
+- le MCP ne doit jamais la tuer.
+
+### Regression path
+- une requête MCP courte ne doit jamais être tuée.
+
+### Edge cases
+- plusieurs requêtes longues concurrentes ;
+- réutilisation de connexion ;
+- course entre fin normale et kill ;
+- tentative de kill quand la requête n’existe déjà plus ;
+- session ID réutilisé après disconnect ;
+- plusieurs requêtes MCP sur une même connexion ou via connexions poolées ;
+- réplica avec visibilité retardée de processlist, si applicable.
+
+### Performance / charge
+- démontre que le polling processlist ne surcharge pas significativement la DB ;
+- borne la fréquence et la durée du polling ;
+- explique le coût attendu.
+
+### Security abuse cases
+- un attaquant essaie de faire tuer une session externe ;
+- une requête externe ressemblant à une requête MCP ne doit pas être tuée ;
+- une collision d’identifiants ou de timing ne doit pas provoquer un mauvais kill.
+
+### Cas spécifique imposé
+Ajouter un scénario reproductible :
+- lancer `SELECT MAX_TIME+5` via client mysql direct, sans passer par MCP ;
+- vérifier via MCP ;
+- s’assurer que cette requête externe n’est pas tuée par le mécanisme auto-kill MCP.
+
+Si la syntaxe exacte `MAX_TIME+5` n’est pas valide telle quelle dans le contexte réel, adapte le test pour produire une requête longue équivalente via mysql direct, tout en conservant l’intention du test : prouver qu’une requête externe longue n’est jamais tuée par le MCP.
+
+## 5. Documentation dédiée à la branche
+Créer ou mettre à jour une documentation spécifique à cette feature.
+
+Je veux une section dédiée, claire et exploitable, contenant :
+1. objectif de la feature ;
+2. architecture de corrélation ownership ;
+3. algorithme de kill ;
+4. garanties de sécurité ;
+5. limites connues ;
+6. différences MariaDB / MySQL / versions ;
+7. privilèges nécessaires ;
+8. stratégie de logs / audit ;
+9. scénarios testés ;
+10. scénarios explicitement refusés pour sécurité ;
+11. raisons pour lesquelles la version précédente était `partial` ;
+12. ce qu’il reste éventuellement hors scope.
+
+Le document doit expliquer noir sur blanc :
+- pourquoi tuer une mauvaise session est dangereux ;
+- comment l’implémentation l’évite ;
+- pourquoi les tests négatifs sont indispensables.
+
+## 6. Validation finale
+Je veux un rendu final structuré avec ces sections exactes :
+
+### 1. Summary
+- ce que tu as modifié ;
+- si la feature passe de `partial` à `success` ou reste `partial` ;
+- niveau de confiance final.
+
+### 2. Ownership model
+- comment tu identifies une requête MCP ;
+- quelles preuves tu utilises ;
+- pourquoi ce n’est pas ambigu.
+
+### 3. Files changed
+- liste des fichiers modifiés / créés ;
+- rôle de chacun.
+
+### 4. Tests
+- liste des tests ajoutés ;
+- ce qu’ils prouvent ;
+- résultat attendu / observé.
+
+### 5. Security analysis
+- comment tu évites le wrong-session kill ;
+- ce qui se passe en cas de doute ;
+- surfaces d’abus restantes.
+
+### 6. Compatibility notes
+- différences MariaDB / MySQL ;
+- différences de `SHOW PROCESSLIST`, `information_schema.processlist`, privilèges, sémantique de `KILL`, etc.
+
+### 7. Operational notes
+- logs ;
+- auditabilité ;
+- coût du polling ;
+- signaux utiles pour exploitation.
+
+### 8. Documentation updated
+- chemin du document ;
+- résumé des sections ajoutées.
+
+### 9. Remaining gaps
+- ce qui reste éventuellement non couvert ;
+- pourquoi ;
+- impact.
+
+# Exigences de qualité
+- Code propre, lisible, commenté seulement quand utile.
+- Pas de complexité cachée.
+- Pas de hack fragile.
+- Pas de validation uniquement “à l’œil”.
+- Pas de conclusion “success” sans test négatif solide.
+- Si une partie ne peut pas être rendue sûre, dis-le explicitement et laisse le statut `partial`.
+
+# Critère décisif
+La feature ne peut être considérée `success` que si tu apportes une preuve crédible et reproductible que :
+1. les requêtes MCP longues sont bien tuées côté DB ;
+2. les requêtes externes ne sont jamais tuées ;
+3. le lien entre requête MCP et session SQL est suffisamment robuste pour éviter les faux positifs ;
+4. le tout est documenté et auditable.
+
+Sinon, laisse la feature en `partial` avec justification précise.
+
+# Important
+Ne te contente pas d’un patch minimal.
+Je veux une implémentation défendable en revue sécurité / production.
+
+Commence par analyser le code existant, puis implémente la solution, ajoute les tests, mets à jour la documentation, et termine par un rapport structuré suivant exactement le format demandé.

--- a/src/AutoKill.php
+++ b/src/AutoKill.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+final class AutoKill
+{
+    public static function enabledForQuery(string $toolName, string $sql): bool
+    {
+        if (!Env::getBool('AUTO_KILL_DB_SELECT', false)) {
+            return false;
+        }
+
+        if ($toolName !== 'db_select') {
+            return false;
+        }
+
+        $timeoutSeconds = Env::getInt('MAX_SELECT_TIME_S', 5);
+        if ($timeoutSeconds <= 0) {
+            return false;
+        }
+
+        $normalized = SqlGuard::stripComments($sql);
+        return preg_match('/^(select|with)\b/i', $normalized) === 1;
+    }
+
+    public static function start(PDO $queryPdo, string $toolName, string $originalSql, string $executedSql): ?array
+    {
+        if (!self::enabledForQuery($toolName, $originalSql)) {
+            return null;
+        }
+
+        $phpBinary = PHP_BINARY;
+        if ($phpBinary === '' || !is_file($phpBinary)) {
+            QueryLogger::log([
+                'event' => 'mcp_auto_kill',
+                'status' => 'disabled',
+                'reason' => 'php_binary_unavailable',
+                'tool' => $toolName,
+            ]);
+            return null;
+        }
+
+        $monitorScript = dirname(__DIR__) . '/bin/mcp-auto-kill-monitor.php';
+        if (!is_file($monitorScript)) {
+            QueryLogger::log([
+                'event' => 'mcp_auto_kill',
+                'status' => 'disabled',
+                'reason' => 'monitor_script_missing',
+                'tool' => $toolName,
+            ]);
+            return null;
+        }
+
+        $token = bin2hex(random_bytes(12));
+        $stateDir = self::stateDirectory();
+        if (!is_dir($stateDir) && !@mkdir($stateDir, 0775, true) && !is_dir($stateDir)) {
+            QueryLogger::log([
+                'event' => 'mcp_auto_kill',
+                'status' => 'disabled',
+                'reason' => 'state_dir_unavailable',
+                'tool' => $toolName,
+            ]);
+            return null;
+        }
+
+        $stopFile = $stateDir . '/' . $token . '.stop';
+        $payload = [
+            'token' => $token,
+            'connectionId' => Db::connectionId($queryPdo),
+            'tool' => $toolName,
+            'dbUser' => Db::dbUser(),
+            'dbName' => (string) Env::get('DB_NAME', ''),
+            'sqlOriginal' => $originalSql,
+            'sqlExecuted' => $executedSql,
+            'timeoutMs' => self::timeoutMs(),
+            'pollMs' => max(50, Env::getInt('AUTO_KILL_POLL_MS', 200)),
+            'stopFile' => $stopFile,
+            'envFile' => getenv('ENV_FILE') ?: (dirname(__DIR__) . '/.env'),
+        ];
+
+        $command = [
+            $phpBinary,
+            $monitorScript,
+            base64_encode((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
+        ];
+
+        $devNull = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? 'NUL' : '/dev/null';
+        $descriptors = [
+            0 => ['file', $devNull, 'r'],
+            1 => ['file', $devNull, 'a'],
+            2 => ['file', $devNull, 'a'],
+        ];
+
+        $process = @proc_open($command, $descriptors, $pipes, dirname(__DIR__), null, ['bypass_shell' => true]);
+        if (!is_resource($process)) {
+            QueryLogger::log([
+                'event' => 'mcp_auto_kill',
+                'status' => 'disabled',
+                'reason' => 'monitor_start_failed',
+                'tool' => $toolName,
+                'connectionId' => $payload['connectionId'],
+            ]);
+            return null;
+        }
+
+        QueryLogger::log([
+            'event' => 'mcp_auto_kill',
+            'status' => 'armed',
+            'tool' => $toolName,
+            'connectionId' => $payload['connectionId'],
+            'timeoutMs' => $payload['timeoutMs'],
+            'token' => $token,
+        ]);
+
+        return [
+            'process' => $process,
+            'stopFile' => $stopFile,
+            'token' => $token,
+            'connectionId' => $payload['connectionId'],
+        ];
+    }
+
+    public static function stop(?array $handle): void
+    {
+        if ($handle === null) {
+            return;
+        }
+
+        $stopFile = (string) ($handle['stopFile'] ?? '');
+        if ($stopFile !== '') {
+            @file_put_contents($stopFile, 'stop');
+        }
+
+        $process = $handle['process'] ?? null;
+        if (is_resource($process)) {
+            $status = @proc_get_status($process);
+            if (is_array($status) && !empty($status['running'])) {
+                @proc_terminate($process);
+                usleep(100000);
+            }
+            @proc_close($process);
+        }
+
+        if ($stopFile !== '') {
+            @unlink($stopFile);
+        }
+    }
+
+    public static function timeoutMs(): int
+    {
+        $timeoutSeconds = Env::getInt('MAX_SELECT_TIME_S', 5);
+        if ($timeoutSeconds <= 0) {
+            return 0;
+        }
+        return $timeoutSeconds * 1000;
+    }
+
+    public static function isKillableProcesslistRow(array $row, int $expectedConnectionId, string $expectedDbUser, string $expectedDbName): bool
+    {
+        $connectionId = (int) ($row['ID'] ?? 0);
+        if ($connectionId !== $expectedConnectionId) {
+            return false;
+        }
+
+        $command = strtoupper(trim((string) ($row['COMMAND'] ?? '')));
+        if (!in_array($command, ['QUERY', 'EXECUTE'], true)) {
+            return false;
+        }
+
+        $info = trim((string) ($row['INFO'] ?? ''));
+        if ($info === '') {
+            return false;
+        }
+
+        $user = (string) ($row['USER'] ?? '');
+        if ($expectedDbUser !== '' && $user !== $expectedDbUser) {
+            return false;
+        }
+
+        $dbName = (string) ($row['DB'] ?? '');
+        if ($expectedDbName !== '' && $dbName !== '' && $dbName !== $expectedDbName) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static function stateDirectory(): string
+    {
+        $custom = trim((string) Env::get('AUTO_KILL_STATE_DIR', ''));
+        if ($custom !== '') {
+            return $custom;
+        }
+
+        return dirname(__DIR__) . '/var/auto-kill';
+    }
+}

--- a/src/Db.php
+++ b/src/Db.php
@@ -14,17 +14,27 @@ final class Db
             return self::$pdo;
         }
 
+        self::$pdo = self::createPdo();
+
+        return self::$pdo;
+    }
+
+    public static function freshPdo(): PDO
+    {
+        return self::createPdo();
+    }
+
+    private static function createPdo(): PDO
+    {
         $dsn = self::buildDsn();
         $options = self::buildPdoOptions();
 
-        self::$pdo = new PDO(
+        return new PDO(
             $dsn,
             (string) Env::get('DB_USER', ''),
             self::dbPassword(),
             $options
         );
-
-        return self::$pdo;
     }
 
     private static function dbPassword(): string
@@ -34,6 +44,11 @@ final class Db
             return $legacy;
         }
         return (string) Env::get('DB_PASSWORD', '');
+    }
+
+    public static function dbUser(): string
+    {
+        return (string) Env::get('DB_USER', '');
     }
 
     private static function buildDsn(): string
@@ -206,6 +221,29 @@ final class Db
         } catch (Throwable) {
             return 0;
         }
+    }
+
+    public static function connectionId(PDO $pdo): int
+    {
+        $value = $pdo->query('SELECT CONNECTION_ID()')->fetchColumn();
+        return is_numeric($value) ? (int) $value : 0;
+    }
+
+    public static function processlistRowById(PDO $pdo, int $connectionId): ?array
+    {
+        $stmt = $pdo->prepare(
+            "SELECT ID, USER, HOST, DB, COMMAND, TIME, STATE, INFO
+             FROM information_schema.PROCESSLIST
+             WHERE ID = ?"
+        );
+        $stmt->execute([$connectionId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return is_array($row) ? $row : null;
+    }
+
+    public static function killQuery(PDO $pdo, int $connectionId): void
+    {
+        $pdo->exec('KILL QUERY ' . max(0, $connectionId));
     }
 
 }

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -756,21 +756,6 @@ final class Tools
         return $message;
     }
 
-    private static function didSuccessfulQueryExceedTimeout(string $sql, int $durationMs): bool
-    {
-        $normalized = SqlGuard::stripComments($sql);
-        if (!preg_match('/^(select|with)\b/i', $normalized)) {
-            return false;
-        }
-
-        $timeoutMs = Env::getInt('MAX_SELECT_TIME_S', 5) * 1000;
-        if ($timeoutMs <= 0) {
-            return false;
-        }
-
-        return $durationMs >= $timeoutMs;
-    }
-
     private static function extractSelectStarTable(string $sql): ?array
     {
         if (!preg_match('/\bfrom\b\s+([`A-Za-z0-9_$.]+)/i', $sql, $matches)) {

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -367,9 +367,10 @@ final class Tools
 
     private static function runPreparedQuery(string $sql, array $params, string $toolName = 'query'): array
     {
-        $pdo = Db::pdo();
         $originalSql = $sql;
         $executedSql = self::applySelectTimeout($sql);
+        $pdo = AutoKill::enabledForQuery($toolName, $originalSql) ? Db::freshPdo() : Db::pdo();
+        $autoKill = AutoKill::start($pdo, $toolName, $originalSql, $executedSql);
         $startedAt = microtime(true);
 
         try {
@@ -446,6 +447,8 @@ final class Tools
                 throw new InvalidArgumentException($publicError, 0, $e);
             }
             throw $e;
+        } finally {
+            AutoKill::stop($autoKill);
         }
     }
 
@@ -745,11 +748,27 @@ final class Tools
             str_contains($m, 'max_statement_time exceeded') ||
             str_contains($m, 'max execution time') ||
             str_contains($m, 'query execution was interrupted') ||
-            str_contains($m, 'execution time exceeded')
+            str_contains($m, 'execution time exceeded') ||
+            str_contains($m, 'configured execution timeout')
         ) {
             return 'guard [execution time reached]';
         }
         return $message;
+    }
+
+    private static function didSuccessfulQueryExceedTimeout(string $sql, int $durationMs): bool
+    {
+        $normalized = SqlGuard::stripComments($sql);
+        if (!preg_match('/^(select|with)\b/i', $normalized)) {
+            return false;
+        }
+
+        $timeoutMs = Env::getInt('MAX_SELECT_TIME_S', 5) * 1000;
+        if ($timeoutMs <= 0) {
+            return false;
+        }
+
+        return $durationMs >= $timeoutMs;
     }
 
     private static function extractSelectStarTable(string $sql): ?array

--- a/tests/AutoKillTest.php
+++ b/tests/AutoKillTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class AutoKillTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_ENV['MAX_SELECT_TIME_S'] = '5';
+        $_ENV['AUTO_KILL_DB_SELECT'] = '0';
+        $_ENV['DB_USER'] = 'cline';
+        $_ENV['DB_NAME'] = 'sakila';
+    }
+
+    public function testEnabledForQueryRequiresExplicitOptIn(): void
+    {
+        $this->assertFalse(AutoKill::enabledForQuery('db_select', 'SELECT SLEEP(7)'));
+
+        $_ENV['AUTO_KILL_DB_SELECT'] = '1';
+        $this->assertTrue(AutoKill::enabledForQuery('db_select', 'SELECT SLEEP(7)'));
+    }
+
+    public function testEnabledForQueryRejectsNonDbSelectTools(): void
+    {
+        $_ENV['AUTO_KILL_DB_SELECT'] = '1';
+
+        $this->assertFalse(AutoKill::enabledForQuery('db_processlist', 'SELECT 1'));
+        $this->assertFalse(AutoKill::enabledForQuery('db_select', 'SHOW PROCESSLIST'));
+    }
+
+    public function testKillableProcesslistRowRequiresExactConnectionAndActiveQuery(): void
+    {
+        $row = [
+            'ID' => 42,
+            'USER' => 'cline',
+            'DB' => 'sakila',
+            'COMMAND' => 'Query',
+            'INFO' => 'SELECT SLEEP(7)',
+        ];
+
+        $this->assertTrue(AutoKill::isKillableProcesslistRow($row, 42, 'cline', 'sakila'));
+        $this->assertFalse(AutoKill::isKillableProcesslistRow($row, 43, 'cline', 'sakila'));
+    }
+
+    public function testKillableProcesslistRowRejectsSleepAndOwnershipMismatch(): void
+    {
+        $sleepRow = [
+            'ID' => 42,
+            'USER' => 'cline',
+            'DB' => 'sakila',
+            'COMMAND' => 'Sleep',
+            'INFO' => '',
+        ];
+        $otherUserRow = [
+            'ID' => 42,
+            'USER' => 'other',
+            'DB' => 'sakila',
+            'COMMAND' => 'Query',
+            'INFO' => 'SELECT SLEEP(7)',
+        ];
+        $otherDbRow = [
+            'ID' => 42,
+            'USER' => 'cline',
+            'DB' => 'mysql',
+            'COMMAND' => 'Query',
+            'INFO' => 'SELECT SLEEP(7)',
+        ];
+
+        $this->assertFalse(AutoKill::isKillableProcesslistRow($sleepRow, 42, 'cline', 'sakila'));
+        $this->assertFalse(AutoKill::isKillableProcesslistRow($otherUserRow, 42, 'cline', 'sakila'));
+        $this->assertFalse(AutoKill::isKillableProcesslistRow($otherDbRow, 42, 'cline', 'sakila'));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,6 +13,7 @@ if (is_file($composerAutoload)) {
     require_once __DIR__ . '/../src/SqlGuard.php';
     require_once __DIR__ . '/../src/JsonRpc.php';
     require_once __DIR__ . '/../src/QueryLogger.php';
+    require_once __DIR__ . '/../src/AutoKill.php';
     require_once __DIR__ . '/../src/Tools.php';
     require_once __DIR__ . '/../src/App.php';
 }

--- a/tests/e2e_guardian/cases/full/GUARD-140-auto-kill-owned-query.test
+++ b/tests/e2e_guardian/cases/full/GUARD-140-auto-kill-owned-query.test
@@ -1,0 +1,21 @@
+TEST_ID="GUARD-140"
+TEST_NAME="Auto kill requête MCP"
+TEST_DESCRIPTION="Une requête MCP trop longue doit être tuée côté SGBD"
+BLOCK="performance-guards"
+TAGS="guard,auto-kill,full"
+PRIORITY="P1"
+TIMEOUT_S=25
+RETRIES=0
+
+DB_ENGINE="${DB_ENGINE:-mariadb}"
+DB_VERSION="${DB_VERSION:-11.8}"
+SSL_MODE="${SSL_MODE:-off}"
+GUARDIAN="${GUARDIAN:-sql-guard}"
+STACK="${STACK:-apache-php}"
+
+PR_ID="none"
+MCP_ID="mcp-core"
+MCP_ENDPOINT="${MCP_ENDPOINT:-http://127.0.0.1:49999/mcp}"
+MCP_TOKEN="${MCP_TOKEN:-my_token}"
+
+COMMAND='AUTO_KILL_DB_SELECT=1 MAX_SELECT_TIME_S=5 MCP_ENDPOINT="$MCP_ENDPOINT" MCP_TOKEN="$MCP_TOKEN" DB_HOST="${DB_HOST:-127.0.0.1}" DB_PORT="${DB_PORT:-3306}" DB_NAME="${DB_NAME:-sakila}" DB_USER="${DB_USER:-my_user_mcp_ro}" DB_PASS="${DB_PASS:-my_password}" ROOT_DB_USER="${ROOT_DB_USER:-root}" ROOT_DB_PASS="${ROOT_DB_PASS:-root_change_me}" ./tests/e2e_guardian/scripts/test_auto_kill_guard.sh owned'

--- a/tests/e2e_guardian/cases/full/GUARD-141-auto-kill-external-query-safe.test
+++ b/tests/e2e_guardian/cases/full/GUARD-141-auto-kill-external-query-safe.test
@@ -1,0 +1,21 @@
+TEST_ID="GUARD-141"
+TEST_NAME="Auto kill respecte les sessions externes"
+TEST_DESCRIPTION="Une requête longue externe ne doit jamais être tuée par le MCP"
+BLOCK="performance-guards"
+TAGS="guard,auto-kill,full,security"
+PRIORITY="P1"
+TIMEOUT_S=35
+RETRIES=0
+
+DB_ENGINE="${DB_ENGINE:-mariadb}"
+DB_VERSION="${DB_VERSION:-11.8}"
+SSL_MODE="${SSL_MODE:-off}"
+GUARDIAN="${GUARDIAN:-sql-guard}"
+STACK="${STACK:-apache-php}"
+
+PR_ID="none"
+MCP_ID="mcp-core"
+MCP_ENDPOINT="${MCP_ENDPOINT:-http://127.0.0.1:49999/mcp}"
+MCP_TOKEN="${MCP_TOKEN:-my_token}"
+
+COMMAND='AUTO_KILL_DB_SELECT=1 MAX_SELECT_TIME_S=5 MCP_ENDPOINT="$MCP_ENDPOINT" MCP_TOKEN="$MCP_TOKEN" DB_HOST="${DB_HOST:-127.0.0.1}" DB_PORT="${DB_PORT:-3306}" DB_NAME="${DB_NAME:-sakila}" DB_USER="${DB_USER:-my_user_mcp_ro}" DB_PASS="${DB_PASS:-my_password}" ROOT_DB_USER="${ROOT_DB_USER:-root}" ROOT_DB_PASS="${ROOT_DB_PASS:-root_change_me}" ./tests/e2e_guardian/scripts/test_auto_kill_guard.sh external'

--- a/tests/e2e_guardian/scripts/test_auto_kill_guard.sh
+++ b/tests/e2e_guardian/scripts/test_auto_kill_guard.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-owned}"
+MCP_TOKEN="${MCP_TOKEN:-my_token}"
+DB_HOST="${DB_HOST:-127.0.0.1}"
+DB_PORT="${DB_PORT:-3306}"
+DB_NAME="${DB_NAME:-sakila}"
+DB_USER="${DB_USER:-my_user_mcp_ro}"
+DB_PASS="${DB_PASS:-my_password}"
+ROOT_USER="${ROOT_DB_USER:-root}"
+ROOT_PASS="${ROOT_DB_PASS:-root_change_me}"
+TIMEOUT_S="${MAX_SELECT_TIME_S:-5}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+MCP_PORT="${AUTO_KILL_TEST_MCP_PORT:-50140}"
+ENV_FILE_PATH="$(mktemp)"
+SERVER_LOG="$(mktemp)"
+SERVER_PID=""
+MCP_ENDPOINT="http://127.0.0.1:${MCP_PORT}/mcp"
+
+cleanup() {
+  if [ -n "$SERVER_PID" ]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+  rm -f "$ENV_FILE_PATH" "$SERVER_LOG"
+}
+
+trap cleanup EXIT
+
+cat >"$ENV_FILE_PATH" <<ENV
+DB_HOST=$DB_HOST
+DB_PORT=$DB_PORT
+DB_NAME=$DB_NAME
+DB_USER=$DB_USER
+DB_PASS=$DB_PASS
+MCP_TOKEN=$MCP_TOKEN
+MAX_ROWS_DEFAULT=1000
+MAX_ROWS_HARD=5000
+MAX_SELECT_TIME_S=$TIMEOUT_S
+WHERE_FULLSCAN_MAX_ROWS=30000
+MAX_CONCURRENT_DB_SELECT=3
+AUTO_KILL_DB_SELECT=1
+MCP_QUERY_LOG=/tmp/mcp_auto_kill_query.log
+ENV
+
+ENV_FILE="$ENV_FILE_PATH" php -S "127.0.0.1:${MCP_PORT}" -t "$ROOT_DIR/public" "$ROOT_DIR/public/index.php" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 20); do
+  if curl -sS "http://127.0.0.1:${MCP_PORT}/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+mcp_call() {
+  local sql="$1"
+  curl -sS -m 30 -X POST "$MCP_ENDPOINT" \
+    -H "content-type: application/json" \
+    -H "authorization: Bearer $MCP_TOKEN" \
+    --data "{\"jsonrpc\":\"2.0\",\"id\":140,\"method\":\"tools/call\",\"params\":{\"name\":\"db_select\",\"arguments\":{\"sql\":\"$sql\"}}}"
+}
+
+mysql_root() {
+  mysql -h"$DB_HOST" -P"$DB_PORT" -u"$ROOT_USER" "-p$ROOT_PASS" "$@"
+}
+
+case "$MODE" in
+  owned)
+    start_ts="$(date +%s)"
+    response="$(mcp_call 'SELECT SLEEP(7)')"
+    end_ts="$(date +%s)"
+    elapsed=$((end_ts - start_ts))
+    echo "$response" | jq -e '.error.message == "guard [execution time reached]"' >/dev/null
+    if [ "$elapsed" -ge 7 ]; then
+      echo "auto-kill owned query took too long: ${elapsed}s" >&2
+      exit 1
+    fi
+    ;;
+  external)
+    mysql -h"$DB_HOST" -P"$DB_PORT" -u"$DB_USER" "-p$DB_PASS" "$DB_NAME" \
+      -e "SELECT SLEEP(20)" >/tmp/external_auto_kill_guard_"$$".out 2>/tmp/external_auto_kill_guard_"$$".err &
+    external_pid=$!
+    trap 'kill "$external_pid" >/dev/null 2>&1 || true; rm -f /tmp/external_auto_kill_guard_"$$".out /tmp/external_auto_kill_guard_"$$".err; cleanup' EXIT
+
+    external_conn_id=""
+    for _ in $(seq 1 20); do
+      external_conn_id="$(mysql_root -Nse "SELECT ID FROM information_schema.PROCESSLIST WHERE USER = '${DB_USER}' AND COMMAND IN ('Query','Execute') AND INFO LIKE 'SELECT SLEEP(20)%' ORDER BY ID ASC LIMIT 1" || true)"
+      if [ -n "$external_conn_id" ]; then
+        break
+      fi
+      sleep 1
+    done
+
+    [ -n "$external_conn_id" ] || { echo "external query not visible in processlist" >&2; exit 1; }
+
+    response="$(mcp_call 'SELECT SLEEP(7)')"
+    echo "$response" | jq -e '.error.message == "guard [execution time reached]"' >/dev/null
+
+    still_running="$(mysql_root -Nse "SELECT COUNT(*) FROM information_schema.PROCESSLIST WHERE ID = ${external_conn_id} AND COMMAND IN ('Query','Execute')" || true)"
+    if [ "${still_running:-0}" -lt 1 ]; then
+      echo "external query was unexpectedly killed" >&2
+      exit 1
+    fi
+
+    wait "$external_pid"
+    rm -f /tmp/external_auto_kill_guard_"$$".out /tmp/external_auto_kill_guard_"$$".err
+    trap cleanup EXIT
+    ;;
+  *)
+    echo "Unknown mode: $MODE" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary
  - add a safe auto-kill mechanism for MCP-owned `db_select` queries
  - use a dedicated DB connection per guarded query and track the exact `CONNECTION_ID()`
  - start a bounded monitor process that only issues `KILL QUERY <id>` when ownership is still proven
  - add PHPUnit coverage and new E2E guard cases `GUARD-140` and `GUARD-141`

  ## Problem
  The previous implementation was still partial.

  A request could time out at the MCP layer while the SQL query was still running on the database side. That leaves behind orphaned expensive queries and defeats the point of a production-
  safe guard.

  At the same time, a wrong auto-kill strategy would be operationally dangerous if it could terminate unrelated sessions.

  ## What changed
  - added `AutoKill` ownership logic
  - added `bin/mcp-auto-kill-monitor.php`
  - when `AUTO_KILL_DB_SELECT=1`, guarded `db_select` requests now use a dedicated PDO connection
  - the monitor captures the exact `CONNECTION_ID()` of that dedicated connection
  - after the timeout window, it re-checks `information_schema.PROCESSLIST`
  - it only executes `KILL QUERY <id>` if ownership is still strictly proven
  - successful-but-too-late queries are normalized to `guard [execution time reached]`

  ## Safety model
  This PR does **not** kill queries using loose heuristics.

  It does **not** kill based only on:
  - SQL text
  - DB user
  - host
  - duration
  - fuzzy processlist matching

  A kill is allowed only if:
  - the exact dedicated MCP connection id is known
  - the processlist row still exists
  - the row is still active (`Query` or `Execute`)
  - ownership is still coherent at kill time

  If there is any doubt, the system refuses to kill.

  ## Tests
  New test ids:
  - `GUARD-140`: long MCP query is auto-killed
  - `GUARD-141`: long external query is preserved

  Added coverage:
  - `tests/AutoKillTest.php`
  - extended timeout detection coverage in `tests/ToolsSelectTimeoutVersionTest.php`
  - new reproducible Bash E2E script:
    - `tests/e2e_guardian/scripts/test_auto_kill_guard.sh`

  ## Validation
  ### PHPUnit
  ```bash
  cd /var/www/mcp-mysql
  php vendor/bin/phpunit --configuration phpunit.xml

  Result:

  - 53 tests, 96 assertions

  ### Real E2E validation

  Validated on mysql:5.6.51 because this version does not provide native query timeout hints, which makes the DB-side kill path meaningful.

  Scenarios validated:

  - MCP-owned SELECT SLEEP(7) exceeds threshold and is terminated
  - external direct SELECT SLEEP(20) is not killed
  - query log shows:
      - mcp_auto_kill armed
      - mcp_auto_kill killed
      - MCP response guard [execution time reached]

  ## Notes

  - auto-kill is opt-in through AUTO_KILL_DB_SELECT=1
  - this PR intentionally focuses on strict ownership and safe targeting first
  - full matrix validation across all supported MariaDB/MySQL/Percona versions remains a follow-up step

